### PR TITLE
Consolidate TypeScript type definitions

### DIFF
--- a/docs/sessions/2025-03-17-11-30-52.md
+++ b/docs/sessions/2025-03-17-11-30-52.md
@@ -1,0 +1,49 @@
+---
+title: "Consolidate Types and Update Import Paths"
+description: "Resolved duplicate type definitions by consolidating them into a single location and updated import paths accordingly"
+pubDate: "2025-03-17T11:30:52.000Z"
+---
+
+# Session Overview
+
+The session was initiated to address duplicate type definitions in the codebase. The main objective was to consolidate types into a single location and ensure all imports reference the correct path.
+
+# Key Activities
+
+- Identified duplicate type definitions in `src/types.ts` and `src/types/index.ts`
+- Analyzed both files to determine the complete set of types
+- Removed redundant `src/types.ts` file
+- Updated import path in `config/index.ts` to reference the correct types location
+- Committed and pushed changes to the `refactor/consolidate-services` branch
+
+# Technical Learnings
+
+- Type definitions were split between two locations:
+  - `src/types.ts`: Only contained `ConversionResult` interface
+  - `src/types/index.ts`: Contained both `Config` and `ConversionResult` interfaces
+- The `Config` interface was only present in `types/index.ts`, making it the more complete source
+- Import paths needed to be explicit about referencing `types/index` rather than just `types`
+
+# Challenges and Solutions
+
+- Challenge: Identifying all files that might be importing from the old types location
+  - Solution: Used `find` command with `grep` to search for any imports containing "types"
+  - Found only one file (`config/index.ts`) needed updating
+
+# Observations and Patterns
+
+- The project follows a pattern of organizing types in a dedicated directory
+- Type definitions are kept minimal and focused on specific use cases
+- The `Config` interface specifically handles environment-related configuration
+
+# Future Considerations
+
+- Consider adding JSDoc comments to type definitions for better documentation
+- Might want to organize types into separate files by domain if the number of types grows
+- Could add validation or utility functions related to these types in the future
+
+# Final Thoughts
+
+The session effectively consolidated type definitions, improving code organization and reducing potential confusion. The changes were straightforward and didn't require extensive refactoring, suggesting good initial project structure. The use of TypeScript for type safety continues to be valuable for maintaining code quality.
+
+The consolidation of types sets a good foundation for future development, making it clearer where type definitions should be placed and how they should be imported. This will be particularly helpful as the project grows and more types are added.


### PR DESCRIPTION
## Changes

- Consolidated duplicate type definitions from `src/types.ts` and `src/types/index.ts` into a single location
- Removed redundant `src/types.ts` file
- Updated import paths to reference `types/index`
- Added session documentation

## Testing

No test files were affected by these changes.

## Documentation

Added session summary in `docs/sessions/2025-03-17-11-30-52.md`