### PR TITLE
Add channel filtering functionality

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,9 @@
 # Discord Bot Token
 DISCORD_TOKEN=your_discord_bot_token
 
+# Discord Channel IDs (comma-separated)
+ALLOWED_CHANNEL_IDS=channel_id1,channel_id2
+
 # Google Cloud Storage
 GCS_BUCKET_NAME=your_bucket_name
 GOOGLE_APPLICATION_CREDENTIALS=path/to/service-account-key.json

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -11,7 +11,17 @@ if (!process.env.GCS_BUCKET_NAME) {
   throw new Error('GCS_BUCKET_NAME is required in environment variables');
 }
 
+if (!process.env.ALLOWED_CHANNEL_IDS) {
+  throw new Error('ALLOWED_CHANNEL_IDS is required in environment variables');
+}
+
+const allowedChannelIds = process.env.ALLOWED_CHANNEL_IDS.split(',').map(id => id.trim());
+if (allowedChannelIds.length === 0) {
+  throw new Error('ALLOWED_CHANNEL_IDS must contain at least one channel ID');
+}
+
 export const config: Config = {
   discordToken: process.env.DISCORD_TOKEN,
   gcsBucketName: process.env.GCS_BUCKET_NAME,
+  allowedChannelIds,
 } as const;

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ client.once(Events.ClientReady, (readyClient) => {
 
 client.on(Events.MessageCreate, async (message) => {
   if (message.author.bot) return;
+  if (!config.allowedChannelIds.includes(message.channelId)) return;
 
   const urls = message.content.match(/https?:\/\/[^\s]+/g);
   if (!urls) return;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,7 @@
 export interface Config {
   discordToken: string;
   gcsBucketName: string;
+  allowedChannelIds: string[];
 }
 
 export interface ConversionResult {


### PR DESCRIPTION
This PR adds channel filtering functionality to the Discord bot. The bot will now only process messages from channels that are explicitly configured in the environment variables.

### Changes
- Added `ALLOWED_CHANNEL_IDS` environment variable
- Updated Config type to include allowed channel IDs
- Added validation for channel configuration
- Modified message handler to only process messages from allowed channels

### How to use
1. Add `ALLOWED_CHANNEL_IDS` to your `.env` file with comma-separated channel IDs
2. The bot will only process URLs from messages in the specified channels

This change helps keep the bot focused and prevents unnecessary processing of URLs in channels where it is not needed.